### PR TITLE
Fix database encoding error for non-UTF systems

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -1,5 +1,5 @@
 CREATE DATABASE bonsai
    WITH OWNER bonsai
-   TEMPLATE template1
+   TEMPLATE template0
    ENCODING 'UTF8'
    CONNECTION LIMIT  -1;


### PR DESCRIPTION
database template must be "template0" because "template1" causes error if default system encoding is not UTF-8